### PR TITLE
[Fix]: DB 커넥션 누수 문제 해결 - SSE 스트리밍 중 트랜잭션 삭제

### DIFF
--- a/src/main/java/akkimi_BE/aja/repository/ChatMessageRepository.java
+++ b/src/main/java/akkimi_BE/aja/repository/ChatMessageRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
@@ -31,4 +32,11 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     
     @Query("SELECT c FROM ChatMessage c WHERE c.consumptionId IN :consumptionIds AND c.speaker = 'BOT' AND c.isFeedback = true")
     List<ChatMessage> findByConsumptionIds(@Param("consumptionIds") List<Long> consumptionIds);
+    
+    @Query("""
+        SELECT c.message, c.maltuId
+        FROM ChatMessage c
+        WHERE c.chatId = :messageId AND c.user.userId = :userId
+    """)
+    Optional<Object[]> findMessageDataById(@Param("messageId") Long messageId, @Param("userId") Long userId);
 }

--- a/src/main/java/akkimi_BE/aja/service/ChatService.java
+++ b/src/main/java/akkimi_BE/aja/service/ChatService.java
@@ -122,18 +122,16 @@ public class ChatService {
         private Long maltuId;
     }
     
-    // 사용자 메시지 조회 - 필요한 데이터만 추출하여 반환
-    @Transactional(readOnly = true)
+    // 사용자 메시지 조회 - 필요한 데이터만 추출하여 반환 (트랜잭션 없음)
     public MessageData getUserMessageData(User user, Long messageId) {
-        ChatMessage userMessage = chatMessageRepository.findById(messageId)
+        Object[] result = chatMessageRepository.findMessageDataById(messageId, user.getUserId())
                 .orElseThrow(() -> new CustomException(HttpErrorCode.MESSAGE_NOT_FOUND));
-
-        if (!userMessage.getUser().getUserId().equals(user.getUserId())) {
-            throw new CustomException(HttpErrorCode.FORBIDDEN_MESSAGE_ACCESS);
-        }
         
-        // 필요한 데이터만 추출하여 트랜잭션 종료
-        return new MessageData(userMessage.getMessage(), userMessage.getMaltuId());
+        String message = (String) result[0];
+        Long maltuId = (Long) result[1];
+        
+        // 필요한 데이터만 추출하여 반환
+        return new MessageData(message, maltuId);
     }
 
     // 2) 스트림 대화 답변 받기 - 트랜잭션 제거 (SSE 장시간 연결로 인한 DB 커넥션 고갈 방지)


### PR DESCRIPTION
- ChatMessageRepository에 프로젝션 쿼리 추가(findMessageDataById)
- ChatService.getUserMessageData()에서 트랜잭션 제거
 - 엔티티 대신 필요한 데이터만 직접 조회하여 커넥션 즉시 반환
- SSE 스트리밍 20초 동안 DB 커넥션 점유 문제 해결